### PR TITLE
[WIP] Initial investigation on Named Entity Recognition in Polish language with Deep Pavlov

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,10 @@
 
 ## Installation
 ```pip install -r requirements.txt```
+
+## Deep Pavlov configuration
+
+```
+pip install deeppavlov
+python -m deeppavlov install ner_ontonotes_bert_mult  # Multi-language NER
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ jupyterlab
 beautifulsoup4
 google
 news-please
+deeppavlov

--- a/test/test_ner_ontonotes_bert_mult.py
+++ b/test/test_ner_ontonotes_bert_mult.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+from deeppavlov import configs, build_model
+
+
+class TestNerOntonotesBertMult(TestCase):
+
+    def test1(self):
+        ner_model = build_model(configs.ner.ner_ontonotes_bert_mult, download=True)
+        result = ner_model(['23 górników z Rudy Śląskiej i członków ich rodzin z wakacji nad morzem wróciło z koronawirusem. '
+                            'Wyjazd zorganizowały związki zawodowe. Wszyscy urlopowicze trafili do kwarantanny. 60 osób upchniętych w autokarze. Wśród nich zakażeni SARS-CoV-2. '
+                            'Tak wyglądał wyjazd nad morze rodzin górników z Rudy Śląskiej. Efekt - wycieczka zmieniła się w ognisko koronawirusa, już stwierdzono zakażenie 23 osób.'])
+        for token, ner in zip(result[0], result[1]):
+            print(token, ner)

--- a/test/test_ner_ontonotes_bert_mult.py
+++ b/test/test_ner_ontonotes_bert_mult.py
@@ -2,12 +2,61 @@ from unittest import TestCase
 from deeppavlov import configs, build_model
 
 
-class TestNerOntonotesBertMult(TestCase):
+ner_types = ['PERSON', 'NORP', 'FACILITY', 'ORGANIZATION', 'GPE', 'LOCATION', 'PRODUCT', 'EVENT',
+                 'WORK OF ART', 'LAW', 'LANGUAGE', 'DATE', 'TIME', 'PERCENT', 'MONEY', 'QUANTITY', 'ORDINAL',
+                 'CARDINAL']
+not_ner = 'O'
+begin_ner = 'B'
+inside_ner = 'I'
 
-    def test1(self):
-        ner_model = build_model(configs.ner.ner_ontonotes_bert_mult, download=True)
-        result = ner_model(['23 górników z Rudy Śląskiej i członków ich rodzin z wakacji nad morzem wróciło z koronawirusem. '
-                            'Wyjazd zorganizowały związki zawodowe. Wszyscy urlopowicze trafili do kwarantanny. 60 osób upchniętych w autokarze. Wśród nich zakażeni SARS-CoV-2. '
-                            'Tak wyglądał wyjazd nad morze rodzin górników z Rudy Śląskiej. Efekt - wycieczka zmieniła się w ognisko koronawirusa, już stwierdzono zakażenie 23 osób.'])
-        for token, ner in zip(result[0], result[1]):
-            print(token, ner)
+
+def print_fragment(fragment, ners, tokens, idx):
+    if len(fragment) > 0:
+        ner_type = ners[idx - 1][2:]
+        if ner_type == 'CARDINAL':
+            print(' '.join(fragment), f'({tokens[idx]}) {ners[idx - 1][2:]}')
+        else:
+            print(' '.join(fragment), ners[idx - 1][2:])
+
+
+class TestNerOntonotesBertMult(TestCase):
+    """
+    Investigation of posibilities of finding named entities within Polish news using Deep Pavlov and their pretrained
+    multi-language BERT model http://docs.deeppavlov.ai/en/master/features/models/ner.html#ner-multi-bert
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.ner_model = build_model(configs.ner.ner_ontonotes_bert_mult, download=True)
+
+    def test2(self):
+        result = self.ner_model(['Do Nowego Sącza dotarły już wszystkie wyniki badań pensjonariuszy oraz '
+                                 'pracowników jednego z Domów Pomocy Społecznej przy ul. Nawojowskiej w Nowym Sączu, '
+                                 'w którym wykryto ognisko koronawirusa. - Łącznie wykonano 275 testów – mówi Luiza '
+                                 'Piątkiewicz, dyrektor Miejskiego Ośrodka Pomocy Społecznej w Nowym Sączu. – '
+                                 'Spośród tych osób mamy 16 pracowników oraz 70 mieszkańców z potwierdzonym '
+                                 'dodatnim wynikiem.',
+                                 '23 górników z Rudy Śląskiej i członków ich rodzin z wakacji nad morzem wróciło '
+                                 'z koronawirusem. Wyjazd zorganizowały związki zawodowe. Wszyscy urlopowicze '
+                                 'trafili do kwarantanny. 60 osób upchniętych w autokarze. Wśród nich zakażeni '
+                                 'SARS-CoV-2. Tak wyglądał wyjazd nad morze rodzin górników z Rudy Śląskiej. '
+                                 'Efekt - wycieczka zmieniła się w ognisko koronawirusa, już stwierdzono zakażenie '
+                                 '23 osób.'
+                                 ])
+        tokens_list = result[0]
+        ners_list = result[1]
+
+        for sentence_idx, (tokens, ners) in enumerate(zip(tokens_list, ners_list)):
+            print(f'\nSentence {sentence_idx+1}')
+            sentence_len = len(tokens)
+            idx = 0
+            fragment = []
+            while idx < sentence_len:
+                if ners[idx] == not_ner:
+                    print_fragment(fragment, ners, tokens, idx)
+                    fragment.clear()
+                    idx += 1
+                    continue
+                fragment.append(tokens[idx])
+                idx += 1
+            print_fragment(fragment, ners, tokens, sentence_len-1)

--- a/test/test_news_please.py
+++ b/test/test_news_please.py
@@ -8,3 +8,19 @@ class TestNewsPlease(TestCase):
         article = downloader.fetch(url)
         print(article.title)
         print(article.maintext)
+
+    def test2(self):
+        # Gazeta wyborcza required subscription and blocks its content for webcrawling
+        url = r'https://wroclaw.wyborcza.pl/wroclaw/7,35771,26231183,ognisko-koronawirusa-na-pogotowiu-jest-wiecej-zakazonych.html'
+        article = downloader.fetch(url)
+        downloader.describe_article(article)
+
+    def test3(self):
+        url = r'https://radio.lublin.pl/2020/08/4-nowe-ogniska-koronawirusa-wojewodztwie-lubelskim/'
+        article = downloader.fetch(url)
+        downloader.describe_article(article)
+
+    def test4(self):
+        url = r'https://m.sadeczanin.info/wiadomosci/nowy-sacz-ognisko-koronawirusa-w-dps-sa-juz-wyniki-badan'
+        article = downloader.fetch(url)
+        downloader.describe_article(article)

--- a/test/test_news_please.py
+++ b/test/test_news_please.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+from webscrapping import downloader
+
+
+class TestNewsPlease(TestCase):
+    def test_read_one_text(self):
+        url = r'https://tvn24.pl/pomorze/koronawirus-w-polsce-gornicy-z-czerwonej-strefy-pojechali-nad-morze-nowe-ognisko-koronawirusa-4670186'
+        article = downloader.fetch(url)
+        print(article.title)
+        print(article.maintext)

--- a/webscrapping/downloader.py
+++ b/webscrapping/downloader.py
@@ -17,9 +17,7 @@ def save_links(links):
 
 
 def fetch(link):
-    article = NewsPlease.from_url(link)
-    print(article.title)
-    print(article.maintext)
+    return NewsPlease.from_url(link)
 
 
 if __name__ == '__main__':

--- a/webscrapping/downloader.py
+++ b/webscrapping/downloader.py
@@ -20,6 +20,24 @@ def fetch(link):
     return NewsPlease.from_url(link)
 
 
+def describe_article(article):
+    print('Authors', article.authors)
+    print('Date download', article.date_download)
+    print('Date modify', article.date_modify)
+    print('Date publish', article.date_publish)
+    print('Description', article.description)
+    print('File name', article.filename)
+    print('Image URL', article.image_url)
+    print('Language', article.language)
+    print('Local path', article.localpath)
+    print('Title', article.title)
+    print('Title page', article.title_page)
+    print('Title RSS', article.title_rss)
+    print('Source domain', article.source_domain)
+    print('Main text', article.maintext)
+    print('URL', article.url)
+
+
 if __name__ == '__main__':
     start = 50
     stop = start + 50


### PR DESCRIPTION
Instruction on how to install Deep Pavlov can be found in `README.md`. 
Then, you can run `test_ner_ontonotes_bert_mult.py` unit test, either from PyCharm or from command line (`python -m unittest discover`).
The output is formatted to display only those entities that were found in the text. For numbers (CARDINAL) the noun that comes after the number is displayed in brackets.